### PR TITLE
add ember-lodash as a dependency

### DIFF
--- a/addon/initializers/ember-i18n-fetch-translations.js
+++ b/addon/initializers/ember-i18n-fetch-translations.js
@@ -1,5 +1,5 @@
 import { assert } from '@ember/debug';
-import merge from 'lodash/merge';
+import { merge } from 'lodash';
 import fetch from 'fetch';
 import { all, hash, reject } from 'rsvp';
 

--- a/package.json
+++ b/package.json
@@ -23,7 +23,8 @@
     "test": "ember try:each"
   },
   "dependencies": {
-    "ember-cli-babel": "^6.6.0"
+    "ember-cli-babel": "^6.6.0",
+    "ember-lodash": "^4.18.0"
   },
   "devDependencies": {
     "broccoli-asset-rev": "^2.4.5",
@@ -43,7 +44,6 @@
     "ember-fetch": "^3.4.4",
     "ember-i18n": "^5.1.0",
     "ember-load-initializers": "^1.0.0",
-    "ember-lodash": "^4.18.0",
     "ember-maybe-import-regenerator": "^0.1.6",
     "ember-resolver": "^4.0.0",
     "ember-source": "~3.0.0",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   },
   "dependencies": {
     "ember-cli-babel": "^6.6.0",
-    "ember-lodash": "^4.18.0"
+    "ember-lodash": "^4"
   },
   "devDependencies": {
     "broccoli-asset-rev": "^2.4.5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2145,7 +2145,7 @@ ember-load-initializers@^1.0.0:
   dependencies:
     ember-cli-babel "^6.0.0-beta.7"
 
-ember-lodash@^4.18.0:
+ember-lodash@^4:
   version "4.18.0"
   resolved "https://registry.yarnpkg.com/ember-lodash/-/ember-lodash-4.18.0.tgz#45de700d6a4f68f1cd62888d90b50aa6477b9a83"
   dependencies:


### PR DESCRIPTION
This PR promotes `ember-lodash` to a dependency, set to `^4`.